### PR TITLE
增加 MACA 环境诊断工具

### DIFF
--- a/tests/test_maca_env_doctor.py
+++ b/tests/test_maca_env_doctor.py
@@ -1,0 +1,23 @@
+import importlib.util
+import unittest
+from pathlib import Path
+
+
+DOCTOR_PATH = Path(__file__).resolve().parents[1] / "tools" / "maca_env_doctor.py"
+spec = importlib.util.spec_from_file_location("maca_env_doctor", DOCTOR_PATH)
+maca_env_doctor = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(maca_env_doctor)
+
+
+class MacaEnvDoctorTest(unittest.TestCase):
+    def test_collect_report_marks_missing_environment(self):
+        report = maca_env_doctor.collect_report({})
+
+        self.assertFalse(report["ok"])
+        self.assertIn("environment", report)
+        self.assertTrue(any(item["name"] == "MACA_PATH" for item in report["checks"]))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/maca_env_doctor.py
+++ b/tools/maca_env_doctor.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+
+def _path_status(path: str | None) -> dict[str, Any]:
+    if not path:
+        return {"path": None, "exists": False, "is_dir": False}
+    resolved = Path(path).expanduser()
+    return {
+        "path": str(resolved),
+        "exists": resolved.exists(),
+        "is_dir": resolved.is_dir(),
+    }
+
+
+def _command_output(command: list[str]) -> dict[str, Any]:
+    try:
+        result = subprocess.run(
+            command,
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        return {
+            "command": command,
+            "returncode": result.returncode,
+            "stdout": result.stdout.strip(),
+            "stderr": result.stderr.strip(),
+        }
+    except Exception as exc:
+        return {"command": command, "error": f"{type(exc).__name__}: {exc}"}
+
+
+def collect_report(env: dict[str, str] | None = None) -> dict[str, Any]:
+    env = env or os.environ
+    maca_path = env.get("MACA_PATH")
+    cuda_path = env.get("CUDA_HOME") or env.get("CUDA_PATH")
+    if not cuda_path and maca_path:
+        cuda_path = str(Path(maca_path) / "tools" / "cu-bridge")
+    clang_path = env.get("MACA_CLANG_PATH")
+    if not clang_path and maca_path:
+        clang_path = str(Path(maca_path) / "mxgpu_llvm" / "bin")
+
+    cucc = shutil.which("cucc")
+    nvcc = shutil.which("nvcc")
+    report: dict[str, Any] = {
+        "python": sys.version.split()[0],
+        "environment": {
+            "MACA_PATH": _path_status(maca_path),
+            "CUDA_HOME_OR_PATH": _path_status(cuda_path),
+            "MACA_CLANG_PATH": _path_status(clang_path),
+            "LD_LIBRARY_PATH_SET": bool(env.get("LD_LIBRARY_PATH")),
+        },
+        "executables": {
+            "cucc": cucc,
+            "nvcc": nvcc,
+        },
+        "libraries": {},
+        "torch": {},
+        "checks": [],
+    }
+
+    if maca_path:
+        maca_root = Path(maca_path)
+        report["libraries"] = {
+            "mcruntime": _path_status(str(maca_root / "lib" / "libmcruntime.so")),
+            "mcblas": _path_status(str(maca_root / "lib" / "libmcblas.so")),
+        }
+
+    if cucc:
+        report["cucc_version"] = _command_output([cucc, "-V"])
+    elif nvcc:
+        report["nvcc_version"] = _command_output([nvcc, "-V"])
+
+    try:
+        import torch
+
+        report["torch"] = {
+            "version": torch.__version__,
+            "cuda_version": getattr(torch.version, "cuda", None),
+            "maca_version": getattr(torch.version, "maca", None),
+            "cuda_available": bool(torch.cuda.is_available()),
+            "device_count": torch.cuda.device_count() if torch.cuda.is_available() else 0,
+        }
+        if torch.cuda.is_available():
+            report["torch"]["device_name_0"] = torch.cuda.get_device_name(0)
+    except Exception as exc:
+        report["torch"] = {"error": f"{type(exc).__name__}: {exc}"}
+
+    required = [
+        ("MACA_PATH", report["environment"]["MACA_PATH"]["is_dir"]),
+        ("CUDA_HOME_OR_PATH", report["environment"]["CUDA_HOME_OR_PATH"]["is_dir"]),
+        ("MACA_CLANG_PATH", report["environment"]["MACA_CLANG_PATH"]["is_dir"]),
+        ("cucc_or_nvcc", bool(cucc or nvcc)),
+    ]
+    for name, ok in required:
+        report["checks"].append({"name": name, "ok": ok})
+    report["ok"] = all(item["ok"] for item in report["checks"])
+    return report
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Collect FlashMLA MACA environment diagnostics.")
+    parser.add_argument("--pretty", action="store_true", help="Print indented JSON.")
+    args = parser.parse_args()
+
+    report = collect_report()
+    print(json.dumps(report, indent=2 if args.pretty else None, sort_keys=True))
+    return 0 if report["ok"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/maca_env_doctor.py
+++ b/tools/maca_env_doctor.py
@@ -40,7 +40,7 @@ def _command_output(command: list[str]) -> dict[str, Any]:
 
 
 def collect_report(env: dict[str, str] | None = None) -> dict[str, Any]:
-    env = env or os.environ
+    env = os.environ if env is None else env
     maca_path = env.get("MACA_PATH")
     cuda_path = env.get("CUDA_HOME") or env.get("CUDA_PATH")
     if not cuda_path and maca_path:
@@ -49,8 +49,9 @@ def collect_report(env: dict[str, str] | None = None) -> dict[str, Any]:
     if not clang_path and maca_path:
         clang_path = str(Path(maca_path) / "mxgpu_llvm" / "bin")
 
-    cucc = shutil.which("cucc")
-    nvcc = shutil.which("nvcc")
+    search_path = env.get("PATH", "")
+    cucc = shutil.which("cucc", path=search_path)
+    nvcc = shutil.which("nvcc", path=search_path)
     report: dict[str, Any] = {
         "python": sys.version.split()[0],
         "environment": {

--- a/tools/maca_env_doctor.py
+++ b/tools/maca_env_doctor.py
@@ -6,10 +6,10 @@ import shutil
 import subprocess
 import sys
 from pathlib import Path
-from typing import Any
+from typing import Any, Dict, List, Optional
 
 
-def _path_status(path: str | None) -> dict[str, Any]:
+def _path_status(path: Optional[str]) -> Dict[str, Any]:
     if not path:
         return {"path": None, "exists": False, "is_dir": False}
     resolved = Path(path).expanduser()
@@ -20,7 +20,7 @@ def _path_status(path: str | None) -> dict[str, Any]:
     }
 
 
-def _command_output(command: list[str]) -> dict[str, Any]:
+def _command_output(command: List[str]) -> Dict[str, Any]:
     try:
         result = subprocess.run(
             command,
@@ -39,7 +39,7 @@ def _command_output(command: list[str]) -> dict[str, Any]:
         return {"command": command, "error": f"{type(exc).__name__}: {exc}"}
 
 
-def collect_report(env: dict[str, str] | None = None) -> dict[str, Any]:
+def collect_report(env: Optional[Dict[str, str]] = None) -> Dict[str, Any]:
     env = os.environ if env is None else env
     maca_path = env.get("MACA_PATH")
     cuda_path = env.get("CUDA_HOME") or env.get("CUDA_PATH")
@@ -52,7 +52,7 @@ def collect_report(env: dict[str, str] | None = None) -> dict[str, Any]:
     search_path = env.get("PATH", "")
     cucc = shutil.which("cucc", path=search_path)
     nvcc = shutil.which("nvcc", path=search_path)
-    report: dict[str, Any] = {
+    report: Dict[str, Any] = {
         "python": sys.version.split()[0],
         "environment": {
             "MACA_PATH": _path_status(maca_path),


### PR DESCRIPTION
该 PR 为 FlashMLA 增加面向沐曦环境的诊断工具，集中检查运行时、编译器和 Python 扩展依赖，降低算子编译和基准测试前的排障成本。

这个修改面向沐曦 GPU 适配场景中比较容易影响开发、构建或验证稳定性的环节，把原来需要人工排查的问题前移到工具链、运行前检查或基准脚本中处理。实现上保持对现有默认行为的兼容，只在检测到明确配置、输入或环境异常时给出更直接的诊断，避免引入额外运行依赖，也方便维护者独立审阅该分支。

已在沐曦算力环境中完成对应分支验证，验证记录包含真实运行日志、命令输出和失败路径检查，本地归档目录为：E:/Documents/muxi/测试报告/FlashMLA_real_maca_validation_20260608。提交分支：`mengz/add-maca-env-doctor`，目标仓库：`MetaX-MACA/FlashMLA`。