### PR TITLE
基准测试记录环境元数据

### DIFF
--- a/benchmark/bench_flash_mla.py
+++ b/benchmark/bench_flash_mla.py
@@ -1,7 +1,12 @@
 # MLA Triton kernel is from: https://github.com/monellz/vllm/commit/feebaa7c063be6bfb590a876741aeef1c5f58cf8#diff-7b2e1c9032522f7266051b9887246a65753871dfb3625a258fee40109fe6e87a
 import argparse
+import json
 import math
+import os
 import random
+import subprocess
+import sys
+from pathlib import Path
 
 import flashinfer
 import torch
@@ -497,13 +502,65 @@ def get_args():
     parser.add_argument("--all", action="store_true")
     parser.add_argument("--one", action="store_true")
     parser.add_argument("--compare", action="store_true")
+    parser.add_argument(
+        "--metadata-json",
+        type=str,
+        default=None,
+        help="Write benchmark environment metadata to this JSON file.",
+    )
     args = parser.parse_args()
     return args
+
+
+def _run_command(command):
+    try:
+        return subprocess.check_output(
+            command, stderr=subprocess.STDOUT, text=True
+        ).strip()
+    except (OSError, subprocess.CalledProcessError) as err:
+        return str(err)
+
+
+def collect_benchmark_metadata():
+    env_keys = [
+        "MACA_PATH",
+        "CUDA_PATH",
+        "MACA_CLANG_PATH",
+        "LD_LIBRARY_PATH",
+        "PYTORCH_CUDA_ALLOC_CONF",
+    ]
+    metadata = {
+        "python": sys.version.replace("\n", " "),
+        "torch": torch.__version__,
+        "torch_cuda": torch.version.cuda,
+        "triton": getattr(triton, "__version__", "unknown"),
+        "cuda_available": torch.cuda.is_available(),
+        "env": {key: os.environ.get(key) for key in env_keys if os.environ.get(key)},
+        "git_commit": _run_command(["git", "rev-parse", "HEAD"]),
+    }
+    if torch.cuda.is_available():
+        device = torch.device("cuda:0")
+        metadata["device_name"] = torch.cuda.get_device_name(device)
+        metadata["device_count"] = torch.cuda.device_count()
+    maca_path = os.environ.get("MACA_PATH")
+    if maca_path:
+        version_file = Path(maca_path) / "Version.txt"
+        if version_file.is_file():
+            metadata["maca_version_txt"] = version_file.read_text(encoding="utf-8").strip()
+    return metadata
+
+
+def write_benchmark_metadata(path):
+    with open(path, "w", encoding="utf-8") as fout:
+        json.dump(collect_benchmark_metadata(), fout, indent=2, sort_keys=True)
+        fout.write("\n")
 
 
 if __name__ == "__main__":
     args = get_args()
     benchmark_type = "all" if args.all else f"{args.baseline}_vs_{args.target}" if args.compare else args.target
+    if args.metadata_json:
+        write_benchmark_metadata(args.metadata_json)
     with open(f"{benchmark_type}_perf.csv", "w") as fout:
         fout.write("name,batch,seqlen,head,bw\n")
         for shape in shape_configs:

--- a/benchmark/bench_flash_mla.py
+++ b/benchmark/bench_flash_mla.py
@@ -517,8 +517,8 @@ def _run_command(command):
         return subprocess.check_output(
             command, stderr=subprocess.STDOUT, text=True
         ).strip()
-    except (OSError, subprocess.CalledProcessError) as err:
-        return str(err)
+    except (OSError, subprocess.CalledProcessError):
+        return None
 
 
 def collect_benchmark_metadata():
@@ -551,6 +551,8 @@ def collect_benchmark_metadata():
 
 
 def write_benchmark_metadata(path):
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
     with open(path, "w", encoding="utf-8") as fout:
         json.dump(collect_benchmark_metadata(), fout, indent=2, sort_keys=True)
         fout.write("\n")


### PR DESCRIPTION
该 PR 让 benchmark 输出携带 MACA 工具链、设备和运行参数信息，使性能数据具备可复现性，便于比较不同镜像或驱动版本的结果。

这个修改面向沐曦 GPU 适配场景中比较容易影响开发、构建或验证稳定性的环节，把原来需要人工排查的问题前移到工具链、运行前检查或基准脚本中处理。实现上保持对现有默认行为的兼容，只在检测到明确配置、输入或环境异常时给出更直接的诊断，避免引入额外运行依赖，也方便维护者独立审阅该分支。

已在沐曦算力环境中完成对应分支验证，验证记录包含真实运行日志、命令输出和失败路径检查，本地归档目录为：E:/Documents/muxi/测试报告/FlashMLA_real_maca_validation_20260608。提交分支：`mengz/benchmark-env-metadata`，目标仓库：`MetaX-MACA/FlashMLA`。