### PR TITLE
延迟导入 FlashMLA 扩展

### DIFF
--- a/flash_mla/__init__.py
+++ b/flash_mla/__init__.py
@@ -3,23 +3,48 @@ __version__ = "1.0.1"
 
 __all__ = ["__version__", "get_mla_metadata", "flash_mla_with_kvcache"]
 
+_INTERFACE_FUNCS = None
+
 
 def _load_interface():
-    try:
-        from flash_mla.flash_mla_interface import flash_mla_with_kvcache, get_mla_metadata
-    except ImportError as exc:
-        raise ImportError(
-            "flash_mla_cuda is not available. Build and install FlashMLA from source "
-            "in a configured MACA environment before calling FlashMLA kernels."
-        ) from exc
-    return get_mla_metadata, flash_mla_with_kvcache
+    global _INTERFACE_FUNCS
+    if _INTERFACE_FUNCS is None:
+        try:
+            from flash_mla.flash_mla_interface import flash_mla_with_kvcache, get_mla_metadata
+        except ImportError as exc:
+            raise ImportError(
+                "flash_mla_cuda is not available. Build and install FlashMLA from source "
+                "in a configured MACA environment before calling FlashMLA kernels."
+            ) from exc
+        _INTERFACE_FUNCS = (get_mla_metadata, flash_mla_with_kvcache)
+    return _INTERFACE_FUNCS
 
 
-def get_mla_metadata(*args, **kwargs):
+def get_mla_metadata(cache_seqlens, num_heads_per_head_k, num_heads_k):
     metadata_func, _ = _load_interface()
-    return metadata_func(*args, **kwargs)
+    return metadata_func(cache_seqlens, num_heads_per_head_k, num_heads_k)
 
 
-def flash_mla_with_kvcache(*args, **kwargs):
+def flash_mla_with_kvcache(
+    q,
+    k_cache,
+    block_table,
+    cache_seqlens,
+    head_dim_v,
+    tile_scheduler_metadata,
+    num_splits,
+    softmax_scale=None,
+    causal=False,
+):
     _, flash_func = _load_interface()
-    return flash_func(*args, **kwargs)
+    return flash_func(
+        q,
+        k_cache,
+        block_table,
+        cache_seqlens,
+        head_dim_v,
+        tile_scheduler_metadata,
+        num_splits,
+        softmax_scale=softmax_scale,
+        causal=causal,
+    )

--- a/flash_mla/__init__.py
+++ b/flash_mla/__init__.py
@@ -1,7 +1,25 @@
 # Adapted from deepseek-ai/FlashMLA(https://github.com/deepseek-ai/FlashMLA)
 __version__ = "1.0.1"
 
-from flash_mla.flash_mla_interface import(
-    get_mla_metadata,
-    flash_mla_with_kvcache
-)
+__all__ = ["__version__", "get_mla_metadata", "flash_mla_with_kvcache"]
+
+
+def _load_interface():
+    try:
+        from flash_mla.flash_mla_interface import flash_mla_with_kvcache, get_mla_metadata
+    except ImportError as exc:
+        raise ImportError(
+            "flash_mla_cuda is not available. Build and install FlashMLA from source "
+            "in a configured MACA environment before calling FlashMLA kernels."
+        ) from exc
+    return get_mla_metadata, flash_mla_with_kvcache
+
+
+def get_mla_metadata(*args, **kwargs):
+    metadata_func, _ = _load_interface()
+    return metadata_func(*args, **kwargs)
+
+
+def flash_mla_with_kvcache(*args, **kwargs):
+    _, flash_func = _load_interface()
+    return flash_func(*args, **kwargs)

--- a/tests/test_lazy_import.py
+++ b/tests/test_lazy_import.py
@@ -1,0 +1,14 @@
+import importlib
+import unittest
+
+
+class LazyImportTest(unittest.TestCase):
+    def test_import_package_without_compiled_extension(self):
+        module = importlib.import_module("flash_mla")
+
+        self.assertEqual(module.__version__, "1.0.1")
+        self.assertTrue(callable(module.get_mla_metadata))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_lazy_import.py
+++ b/tests/test_lazy_import.py
@@ -1,13 +1,71 @@
 import importlib
+import inspect
+import sys
+import types
 import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 
 class LazyImportTest(unittest.TestCase):
+    def tearDown(self):
+        sys.modules.pop("flash_mla.flash_mla_interface", None)
+        sys.modules.pop("flash_mla", None)
+
     def test_import_package_without_compiled_extension(self):
         module = importlib.import_module("flash_mla")
 
         self.assertEqual(module.__version__, "1.0.1")
-        self.assertTrue(callable(module.get_mla_metadata))
+        self.assertEqual(
+            list(inspect.signature(module.get_mla_metadata).parameters),
+            ["cache_seqlens", "num_heads_per_head_k", "num_heads_k"],
+        )
+        self.assertEqual(
+            list(inspect.signature(module.flash_mla_with_kvcache).parameters),
+            [
+                "q",
+                "k_cache",
+                "block_table",
+                "cache_seqlens",
+                "head_dim_v",
+                "tile_scheduler_metadata",
+                "num_splits",
+                "softmax_scale",
+                "causal",
+            ],
+        )
+
+    def test_interface_functions_are_cached_after_first_load(self):
+        calls = []
+        fake_interface = types.ModuleType("flash_mla.flash_mla_interface")
+
+        def fake_get_mla_metadata(*args):
+            calls.append(("metadata", args))
+            return "metadata"
+
+        def fake_flash_mla_with_kvcache(*args, **kwargs):
+            calls.append(("flash", args, kwargs))
+            return "flash"
+
+        fake_interface.get_mla_metadata = fake_get_mla_metadata
+        fake_interface.flash_mla_with_kvcache = fake_flash_mla_with_kvcache
+        sys.modules["flash_mla.flash_mla_interface"] = fake_interface
+
+        module = importlib.import_module("flash_mla")
+        module._INTERFACE_FUNCS = None
+
+        self.assertEqual(module.get_mla_metadata("seq", 2, 3), "metadata")
+        sys.modules.pop("flash_mla.flash_mla_interface", None)
+        self.assertEqual(module.get_mla_metadata("cached", 4, 5), "metadata")
+
+        self.assertEqual(
+            calls,
+            [
+                ("metadata", ("seq", 2, 3)),
+                ("metadata", ("cached", 4, 5)),
+            ],
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
该 PR 将 FlashMLA 扩展导入延后到真正执行测试时，使命令行参数解析、环境诊断和文档示例在扩展未编译时仍可运行。

这个修改面向沐曦 GPU 适配场景中比较容易影响开发、构建或验证稳定性的环节，把原来需要人工排查的问题前移到工具链、运行前检查或基准脚本中处理。实现上保持对现有默认行为的兼容，只在检测到明确配置、输入或环境异常时给出更直接的诊断，避免引入额外运行依赖，也方便维护者独立审阅该分支。

已在沐曦算力环境中完成对应分支验证，验证记录包含真实运行日志、命令输出和失败路径检查，本地归档目录为：E:/Documents/muxi/测试报告/FlashMLA_real_maca_validation_20260608。提交分支：`mengz/lazy-extension-import`，目标仓库：`MetaX-MACA/FlashMLA`。